### PR TITLE
query handler: level set using __volume_to_level

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -104,7 +104,7 @@ class VolumeSkill(MycroftSkill):
     @intent_handler(IntentBuilder("QueryVolume").require(
         "Volume").require("Query"))
     def handle_query_volume(self, message):
-        level = self.__get_volume_level(message, self.mixer.getvolume()[0])
+        level = self.__volume_to_level(self.mixer.getvolume()[0])
         self.speak_dialog('volume.is', data={'volume': round(level)})
 
     def __communicate_volume_change(self, message, dialog, code, changed):


### PR DESCRIPTION
A possible solution to simplify handle_query_volume 
- get current volume from mixer
- convert to Mycroft level

This resolves the issues I was seeing where levels 6-11 would be reported back as one level lower. Level 1 would report back as 8. However I don't really understand why the existing line was __get_volume_level and passing in the message so I may not be catching all cases.