### PR TITLE
fix handling when in/decreasing to x level

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -93,7 +93,8 @@ class VolumeSkill(MycroftSkill):
                                   data={"percent": vol/100.0}))
 
     @intent_handler(IntentBuilder("SetVolume").require(
-        "Volume").require("Level"))
+        "Volume").require("Level").optionally(
+        "Increase").optionally("Decrease"))
     def handle_set_volume(self, message):
         level = self.__get_volume_level(message, self.mixer.getvolume()[0])
         self._setvolume(self.__level_to_volume(level))


### PR DESCRIPTION
If the device is currently set to volume level 5, and a user says:
"increase volume to 8"
The IncreaseVolume handler is triggered, volume is incremented by 1 and the new level is 6, not 8.

It looks like both the increase and set handlers match on two vocab files. So adding increase and decrease vocab as optional increases the match strength.