### PR TITLE
Feature/listen ducking

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -99,9 +99,9 @@ class VolumeSkill(MycroftSkill):
         self.add_event('mycroft.volume.unmute',
                        self.handle_unmute_volume)
         self.add_event('recognizer_loop:record_begin',
-                       self._mute_volume)
+                       self.duck)
         self.add_event('recognizer_loop:record_end',
-                       self._unmute_volume)
+                       self.unduck)
 
         self.vol_before_mute = self.__get_system_volume()
 
@@ -219,6 +219,14 @@ class VolumeSkill(MycroftSkill):
                     .require("Increase").optionally("MaxVolume"))
     def handle_max_volume_increase_to_max(self, message):
         self.handle_max_volume(message)
+
+    def duck(self, message):
+        if self.settings.get('ducking', True):
+            self._mute_volume()
+
+    def unduck(self, message):
+        if self.settings.get('ducking', True):
+            self._unmute_volume()
 
     def _mute_volume(self, message=None, speak=False):
         self.log.info('MUTING!')

--- a/settingsmeta.yaml
+++ b/settingsmeta.yaml
@@ -1,0 +1,9 @@
+name: Home Assistant
+skillMetadata:
+  sections:
+  - name: Ducking
+    fields:
+    - name: ducking
+      type: checkbox
+      label: Duck while listening
+      value: True


### PR DESCRIPTION
Duck while listening

- Mixer is now fetched before each action using a property
- handlers for recognizer_loop:record_begin and recognizer_loop:record_end to duck / unduck respectively
- Settingsmeta for enabling / disabling ducking