### PR TITLE
fix max volume on Mark II

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -207,11 +207,11 @@ class VolumeSkill(MycroftSkill):
                     .require("Volume").optionally("Increase")
                     .require("MaxVolume"))
     def handle_max_volume(self, message):
+        self._setvolume(self.settings["max_volume"])
         speak_message = message.data.get('speak_message', True)
         if speak_message:
             self.speak_dialog('max.volume')
             wait_while_speaking()
-        self._setvolume(self.settings["max_volume"], emit=False)
         self.bus.emit(Message('mycroft.volume.duck'))
 
     @intent_handler(IntentBuilder("MaxVolumeIncreaseMax")


### PR DESCRIPTION
Possible fix for "set volume to maximum" on Mark II?

Have let `emit` default to `True` as it does with other volume changes.
Also moved the volume change above speak_dialog so this is output at the new volume rather than previous volume.