### PR TITLE
Add pyalsaaudio as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyalsaaudio


### PR DESCRIPTION
Core removed dependency of pyalsa when the requirements.txt was split into multiple files [#2575](https://github.com/MycroftAI/mycroft-core/pull/2575).

resolves #62 