### PR TITLE
Allow users to specify a default volume

### DIFF
--- a/settingsmeta.yaml
+++ b/settingsmeta.yaml
@@ -6,3 +6,9 @@ skillMetadata:
       type: checkbox
       label: Duck while listening
       value: "true"
+  - name: Defaults
+    fields:
+      - name: default_volume
+        type: number
+        label: Default volume percent
+        value: "50"

--- a/settingsmeta.yaml
+++ b/settingsmeta.yaml
@@ -10,5 +10,5 @@ skillMetadata:
     fields:
       - name: default_volume
         type: number
-        label: Default volume percent
+        label: Default volume as a percentage
         value: "50"


### PR DESCRIPTION
#### Description
Allow users to specify a preferred volume every time Mycroft starts. Maybe nice to have?
Volume is specified as a percentage, and is available in a new section, under the "Ducking" section when the user goes here: https://account.mycroft.ai/skills.
Quite handy to avoid confusion if for some reason the volume was set super low before the last reboot, and to be able to set the volume one likes right from the start (I personally always need to lower a tad the hardcoded default volume).


#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
 Manual testing by blacklisting the official volume skill, adding the new one, and verifying that 1) it boots as it should and 2) in the cli we can check that the volume is set correctly. In the cli, testing increasing, decreasing the volume, and the automated tests should not fail either to verify that we didnt break anything.

#### Documentation
No existing docstrings to update

#### CLA
[x]