### PR TITLE
Allow end user to specify a default volume as a percentage value

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -281,7 +281,7 @@ class VolumeSkill(MycroftSkill):
         if speak:
             self.speak_dialog(
                 'reset.volume',
-                data={'volume':self.__volume_to_level(
+                data={'volume': self.__volume_to_level(
                     self.settings["default_volume"])})
 
     # Unmute/Reset Volume Intent Handlers

--- a/settingsmeta.yaml
+++ b/settingsmeta.yaml
@@ -6,3 +6,9 @@ skillMetadata:
       type: checkbox
       label: Duck while listening
       value: "true"
+  - name: Defaults
+    fields:
+      - name: default_volume
+        type: number
+        label: Default volume as a percentage
+        value: "50"


### PR DESCRIPTION
#### Description
This PR allows the end-user to specify a preferred default volume in the settings on the Mycroft website (here: https://account.mycroft.ai/skills ).
The volume is set as a percentage value and not a level value.
There is now a new settings "section" under the existing "Ducking" one. Screenshot: https://photos.app.goo.gl/MD5T7rBSJ9mL5GqX7

#### Type of PR
- [x] Feature implementation

#### Testing
Testing was done with:
- blacklisting the original volume skill and installing the modified one. Mycroft starts as expected, volume is set to the desired default value, and volume commands are still working.

#### Documentation
There was no existing docstring to modify
