### PR TITLE
Add custom audio hardware settings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -72,7 +72,14 @@ class VolumeSkill(MycroftSkill):
         try:
             # If there are only 1 mixer use that one
             mixers = alsa_mixers()
-            if len(mixers) == 1:
+            custom_settings = self.settings.get('use_custom_audio_settings', False)
+            if custom_settings:
+                # In case of custom settings use those
+                card_index = self.settings.get('card_index', -1)
+                control_name = self.settings.get('control_name', 'Master')
+                mixer = Mixer(control=control_name, cardindex=card_index)
+            elif len(mixers) == 1:
+                # If there are only 1 mixer use that one
                 mixer = Mixer(mixers[0])
             elif 'Master' in mixers:
                 # Try using the default mixer (Master)

--- a/settingsmeta.yaml
+++ b/settingsmeta.yaml
@@ -6,3 +6,17 @@ skillMetadata:
       type: checkbox
       label: Duck while listening
       value: "true"
+  - name: Custom audio settings
+    fields:
+    - name: use_custom_audio_settings
+      type: checkbox
+      label: Use custom audio settings
+      value: "false"
+    - name: card_index
+      type: number
+      label: Sound card index
+      value: -1
+    - name: control_name
+      type: text
+      label: Control name
+      value: "Master"


### PR DESCRIPTION
Custom settings for ALSA in case of multiple sound cards (hardware) installed in the system. 
Background:
In my Pycroft I installed `HifiBerry AMP HiFi tas5713` sound card and it's visible in the system as a card no 1
```
card 0: Headphones [bcm2835 Headphones], device 0: bcm2835 Headphones [bcm2835 Headphones]
card 1: sndrpihifiberry [snd_rpi_hifiberry_amp], device 0: HifiBerry AMP HiFi tas5713.1-001b-0 [HifiBerry AMP HiFi tas5713.1-001b-0]
...
```
and what is more important it has two different volume controls: `Master` and `Channels`
in my case I decided to use `Channels` to control a volume.

I think these settings will be useful for some customers