### PR TITLE
Ensure long form "50 percent" is registered as Adapt entity

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -97,8 +97,11 @@ class VolumeSkill(MycroftSkill):
 
     def initialize(self):
         # Register handlers to detect percentages as reported by STT
+        # Different STT engines might return "50%" or "50 percent"
         for i in range(101):  # numbers 0 to 100
             self.register_vocabulary(str(i) + '%', 'Percent')
+            percent_string = ' '.join([str(i), self.translate('percent')])
+            self.register_vocabulary(percent_string, 'Percent')
 
         # Register handlers for messagebus events
         self.add_event('mycroft.volume.increase',

--- a/__init__.py
+++ b/__init__.py
@@ -135,7 +135,7 @@ class VolumeSkill(MycroftSkill):
         if emit:
             # Notify non-ALSA systems of volume change
             self.bus.emit(Message('mycroft.volume.set',
-                                  data={"percent": vol/100.0}))
+                                  data={"percent": vol / 100.0}))
 
     # Change Volume to X (Number 0 to) Intent Handlers
     @intent_handler(IntentBuilder("SetVolume").require("Volume")
@@ -361,7 +361,7 @@ class VolumeSkill(MycroftSkill):
             self.log.debug('Volume before mute: {}'.format(vol))
         else:
             vol_msg = self.bus.wait_for_response(
-                                Message("mycroft.volume.get", {'show': show}))
+                Message("mycroft.volume.get", {'show': show}))
             if vol_msg:
                 vol = int(vol_msg.data["percent"] * 100)
 
@@ -383,7 +383,7 @@ class VolumeSkill(MycroftSkill):
                 elif (level > self.MAX_LEVEL):
                     # Guess that the user said something like 100 percent
                     # so convert that into a level value
-                    level = self.MAX_LEVEL * level/100
+                    level = self.MAX_LEVEL * level / 100
             except ValueError:
                 pass
 

--- a/test/behave/volume.feature
+++ b/test/behave/volume.feature
@@ -72,6 +72,8 @@ Feature: volume control
   Examples: change volume to a percent
     | change volume to a percent |
     | volume 80 percent |
+    | set volume to 70 percent |
+    | set volume to 87% |
 
   Scenario Outline: max volume
     Given an english speaking user


### PR DESCRIPTION
#### Description
Different STT engines will return text in different formats. This ensures text returned in the long form "50 percent" is still registered as an Adapt entity. These were being captured most of the time, but could be over matched by other intents like brightness even with "volume" included in the utterance as the "Percent" entity wasn't present.

Thanks to @olzeke51 and @sgee_ who reported this in Mycroft Chat.

#### Type of PR
- [x] Bugfix

#### Testing
VK tests updated.