### PR TITLE
dont kill active media skills

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -47,6 +47,7 @@ class VolumeSkill(MycroftSkill):
 
     def __init__(self):
         super(VolumeSkill, self).__init__("VolumeSkill")
+        self.skill_control.category = 'system'
         self.settings["default_level"] = 6  # can be 0 (off) to 10 (max)
         self.settings["min_volume"] = 0     # can be 0 to 100
         if self.config_core['enclosure'].get('platform') == 'mycroft_mark_1':


### PR DESCRIPTION
#### Description
Fixes issue with inter skill behavior. will now not kill an active common play skill
If needed follow up with as much detail as required.

#### Type of PR

- [x] Bugfix

#### Testing
while a common play skill is playing change the volume. active skill should not stop

#### Documentation
No, needs addtl VK Tests
