### PR TITLE
WIP: Extract platform dependent code out of Skill

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -21,7 +21,7 @@ from mycroft.skills.core import MycroftSkill, intent_handler
 from mycroft.util import play_wav
 from mycroft.util.parse import extract_number
 
-from .hal import get_alsa_mixer
+from .hal import construct_HAL, get_alsa_mixer
 
 
 ALSA_PLATFORMS = ['mycroft_mark_1', 'picroft', 'unknown']
@@ -57,6 +57,8 @@ class VolumeSkill(MycroftSkill):
         self.volume_sound = join(dirname(__file__), "blop-mark-diangelo.wav")
         self.vol_before_mute = None
         self._alsa_mixer = None
+        # Instantiate the HAL emulator
+        self.HAL = construct_HAL('ALSA')
 
     def _clear_mixer(self):
         """For Unknown platforms reinstantiate the mixer.
@@ -108,10 +110,11 @@ class VolumeSkill(MycroftSkill):
         # TODO: Remove this and control volume at the Enclosure level in
         # response to the mycroft.volume.set message.
 
-        if emit:
-            # Notify non-ALSA systems of volume change
-            self.bus.emit(Message('mycroft.volume.set',
-                                  data={"percent": vol/100.0}))
+        # if emit:
+        # Notify non-ALSA systems of volume change
+        self.log.info("YESYINGEINSELMSHlkjnrgeknjrgkljnlkenr")
+        self.bus.emit(Message('mycroft.volume.set',
+                                data={"percent": vol/100.0}))
 
     # Change Volume to X (Number 0 to) Intent Handlers
     @intent_handler(IntentBuilder("SetVolume").require("Volume")

--- a/__init__.py
+++ b/__init__.py
@@ -21,7 +21,7 @@ from mycroft.skills.core import MycroftSkill, intent_handler
 from mycroft.util import play_wav
 from mycroft.util.parse import extract_number
 
-from .hal import construct_HAL, get_alsa_mixer
+from .hal import HALFactory
 
 
 ALSA_PLATFORMS = ['mycroft_mark_1', 'picroft', 'unknown']
@@ -58,7 +58,7 @@ class VolumeSkill(MycroftSkill):
         # Instantiate the HAL emulator
         self.platform = self.config_core['enclosure'].get('platform', 'unknown')
         if self.platform in ALSA_PLATFORMS:
-            self.HAL = construct_HAL('ALSA', self.settings)
+            self.HAL = HALFactory.create('ALSA', self.settings)
         else:
             self.HAL = None    
 

--- a/hal/__init__.py
+++ b/hal/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""This is a temporary module to emulate the Hardware Abstraction Layer (HAL).
+
+It is intended to make a simpler transition from the current Volume Skill that
+directly interfaces with ALSA, to one that communicates changes to the HAL via
+the message bus.
+
+This module will be deprecated at the earliest possible moment.
+"""
+from .alsa import get_alsa_mixer

--- a/hal/__init__.py
+++ b/hal/__init__.py
@@ -21,4 +21,4 @@ the message bus.
 This module will be deprecated at the earliest possible moment.
 """
 from .alsa import get_alsa_mixer
-from .hal import construct_HAL
+from .hal import HALFactory

--- a/hal/alsa.py
+++ b/hal/alsa.py
@@ -1,0 +1,53 @@
+# Copyright 2021 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Provides access to the ALSA audio system.
+
+DEPRECATION NOTICE: 
+This will shortly be moved out of the Volume Skill to the Hardware Abstraction
+Layer (HAL). The Volume Skill will be emitting messages to the bus, and the
+HAL will be responsible for managing the system state.
+"""
+
+from alsaaudio import Mixer, mixers as alsa_mixers
+
+from mycroft.util import LOG
+
+def get_alsa_mixer(self):
+    LOG.debug('Finding Alsa Mixer for control...')
+    mixer = None
+    try:
+        # If there are only 1 mixer use that one
+        mixers = alsa_mixers()
+        if len(mixers) == 1:
+            mixer = Mixer(mixers[0])
+        elif 'Master' in mixers:
+            # Try using the default mixer (Master)
+            mixer = Mixer('Master')
+        elif 'PCM' in mixers:
+            # PCM is another common one
+            mixer = Mixer('PCM')
+        elif 'Digital' in mixers:
+            # My mixer is called 'Digital' (JustBoom DAC)
+            mixer = Mixer('Digital')
+        else:
+            # should be equivalent to 'Master'
+            mixer = Mixer()
+    except Exception:
+        # Retry instanciating the mixer with the built-in default
+        try:
+            mixer = Mixer()
+        except Exception as e:
+            LOG.error('Couldn\'t allocate mixer, {}'.format(repr(e)))
+    return mixer

--- a/hal/base.py
+++ b/hal/base.py
@@ -21,17 +21,28 @@ HAL will be responsible for managing the system state.
 """
 
 from mycroft.messagebus.client import MessageBusClient
+from mycroft.messagebus.message import Message
 from mycroft.util import LOG, start_message_bus_client
 
 class HAL():
     """Emulate the Hardware Abstraction Layer (HAL) for audio.
 
     This class will be deprecated at the earliest possible moment.
+
+    Terminology:
+       "Level" =  Mycroft volume levels, from 0 to 10
+       "Volume" = ALSA mixer setting, from 0 to 100
     """
-    def __init__(self):
+    def __init__(self, settings):
+        self.default_volume = settings.get('default_volume', 60)
+        self.min_volume = settings.get('min_volume', 0)
+        self.max_volume = settings.get('max_volume', 83)
+        self.volume_step = (self.max_volume - self.min_volume) / 10
+        self.vol_before_mute = None
+
         self.bus = MessageBusClient()
         self.register_volume_control_handlers()
-        start_message_bus_client("AUDIO_HAL", self.bus)
+        start_message_bus_client('AUDIO_HAL', self.bus)
     
     def register_volume_control_handlers(self):
         self.bus.on('mycroft.volume.get', self._get_volume)
@@ -51,26 +62,65 @@ class HAL():
         """Set the volume level."""
         pass
 
+    def _show_volume(self):
+        """Perform any hardware based display of volume level."""
+        pass
+
+    def _set_default_volume(self, message):
+        self.default_volume = message.data['default_volume']
+
     def _decrease_volume(self, message):
         """Decrease the volume by 10%."""
-        pass
+        current_volume = self._get_volume()
+        target_volume = current_volume - self.volume_step
+        request_data = {'percent': target_volume / 100}
+        response = self._set_volume(Message('mycroft.volume.set', data=request_data))
+        if response['success']:
+            self.bus.emit(message.reply('mycroft.volume.decrease.response', 
+                                    data=response))
 
     def _increase_volume(self, message):
         """Increase the volume by 10%."""
-        pass
+        current_volume = self._get_volume()
+        target_volume = current_volume + self.volume_step
+        request_data = {'percent': target_volume / 100}
+        response = self._set_volume(Message('mycroft.volume.set', data=request_data))
+        if response['success']:
+            self.bus.emit(message.reply('mycroft.volume.increased', data=response))
 
     def _mute_volume(self, message):
         """Mute the audio output."""
-        pass
+        self.volume_before_mute = self._get_volume()
+        LOG.debug('Muting. Volume before mute: {}'.format(self.volume_before_mute))
+        self._set_volume(Message('mycroft.volume.set',
+                                 data={'percentage': 0}))
+        self.bus.emit(message.reply('mycroft.volume.muted', data={'success': true}))
     
     def _unmute_volume(self, message):
         """Unmute the audio output returning to previous volume level."""
-        pass
+        LOG.debug('Unmuting to volume before mute: {}'.format(self.volume_before_mute))
+        request_data = {'percentage': self.volume_before_mute / 100}
+        response = self.bus.wait_for_response(Message('mycroft.volume.set', 
+                                                      data=request_data))
+        if response and response.data['success']:
+            self.bus.emit(message.reply('mycroft.volume.unmuted', 
+                                    data=response.data))
 
     def _duck(self, message):
         """Temporarily duck (significantly lower) audio output."""
-        pass
+        if self.settings.get('ducking', True):
+            self._mute_volume()
 
     def _unduck(self, message):
         """Restore audio output volume after ducking."""
         pass
+
+    def constrain_volume(self, target_volume):
+        """Ensure volume is within the min and max values."""
+        if target_volume > self.max_volume:
+            settable_volume = self.max_volume
+        elif target_volume < self.min_volume:
+            settable_volume = self.min_volume
+        else:
+            settable_volume = target_volume
+        return settable_volume

--- a/hal/hal.py
+++ b/hal/hal.py
@@ -15,15 +15,15 @@
 
 from .alsa import AlsaHAL
 
-def construct_HAL(hal_type):
+def construct_HAL(hal_type, settings):
     """Emulate the Hardware Abstraction Layer (HAL) for audio management.
 
     This class will be deprecated at the earliest possible moment.
     """
     hal = None
-    if hal_type == 'pulseaudio':
-        # hal = PulseaudioHAL()
-        pass
     if hal_type == 'ALSA':
-        hal = AlsaHAL()
+        hal = AlsaHAL(settings)
+    if hal_type == 'pulseaudio':
+        # hal = PulseaudioHAL(settings)
+        pass
     return hal

--- a/hal/hal.py
+++ b/hal/hal.py
@@ -12,13 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""This is a temporary module to emulate the Hardware Abstraction Layer (HAL).
 
-It is intended to make a simpler transition from the current Volume Skill that
-directly interfaces with ALSA, to one that communicates changes to the HAL via
-the message bus.
+from .alsa import AlsaHAL
 
-This module will be deprecated at the earliest possible moment.
-"""
-from .alsa import get_alsa_mixer
-from .hal import construct_HAL
+def construct_HAL(hal_type):
+    """Emulate the Hardware Abstraction Layer (HAL) for audio management.
+
+    This class will be deprecated at the earliest possible moment.
+    """
+    hal = None
+    if hal_type == 'pulseaudio':
+        # hal = PulseaudioHAL()
+        pass
+    if hal_type == 'ALSA':
+        hal = AlsaHAL()
+    return hal

--- a/hal/hal.py
+++ b/hal/hal.py
@@ -14,6 +14,7 @@
 #
 
 from .alsa import AlsaHAL
+from .mark1 import Mark1HAL
 
 class HALFactory:
     """Emulate the Hardware Abstraction Layer (HAL) for audio management.
@@ -21,7 +22,8 @@ class HALFactory:
     This class will be deprecated at the earliest possible moment.
     """
     CLASSES = {
-        "ALSA": AlsaHAL
+        "ALSA": AlsaHAL,
+        "Mark_1": Mark1HAL
     }
 
     @staticmethod

--- a/hal/hal.py
+++ b/hal/hal.py
@@ -15,15 +15,16 @@
 
 from .alsa import AlsaHAL
 
-def construct_HAL(hal_type, settings):
+class HALFactory:
     """Emulate the Hardware Abstraction Layer (HAL) for audio management.
 
     This class will be deprecated at the earliest possible moment.
     """
-    hal = None
-    if hal_type == 'ALSA':
-        hal = AlsaHAL(settings)
-    if hal_type == 'pulseaudio':
-        # hal = PulseaudioHAL(settings)
-        pass
-    return hal
+    CLASSES = {
+        "ALSA": AlsaHAL
+    }
+
+    @staticmethod
+    def create(hal_type, settings):
+        hal = HALFactory.CLASSES.get(hal_type)
+        return hal(settings)

--- a/hal/mark1.py
+++ b/hal/mark1.py
@@ -1,0 +1,40 @@
+# Copyright 2021 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Provides access to the ALSA audio system.
+
+DEPRECATION NOTICE: 
+This will shortly be moved out of the Volume Skill to the Hardware Abstraction
+Layer (HAL). The Volume Skill will be emitting messages to the bus, and the
+HAL will be responsible for managing the system state.
+"""
+
+from mycroft.util import LOG
+
+from .alsa import AlsaHAL
+
+class Mark1HAL(AlsaHAL):
+    """Emulate the Hardware Abstraction Layer (HAL) for the Mark 1.
+
+    This class will be deprecated at the earliest possible moment.
+    """
+    def __init__(self, settings):
+        super().__init__(settings)
+        self._enclosure = EnclosureAPI(self.bus, self.__class__.__name__)
+
+    def _show_volume(self, volume):
+        """Perform any hardware based display of volume level."""
+        level = round(volume / 10)  # convert % to int(0..10)
+        self._enclosure.eyes_volume(new_level)
+        pass


### PR DESCRIPTION
#### Description
Currently the Volume Skill has lots of ALSA specific code embedded in it. I took a stab at starting to extract out the platform dependent code. The intention is that this code will be moved to the Hardware Abstraction Layer (HAL) - formerly known as "enclosure" but there are way too many things that are "enclosures". 

For the moment, I've created a little HAL "emulator" in the Skill that should only be interacted with via the bus. Once the real HAL interface is ready we should be able to delete the module from the Skill and the rest will continue to function as normal.

Interested in any thoughts on this approach before I bother going too far, so opening a work-in-progress PR.

Most recently raised in https://github.com/MycroftAI/enclosure-picroft/pull/153

#### Type of PR
- [ ] Bugfix
- [ ] Feature implementation
- [x] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
- Set the volume
- Decrease / increase the volume

#### Documentation
Docstrings included

#### CLA
- [x] Yes