### PR TITLE
Switch steps to use new message waiter

### DIFF
--- a/test/behave/steps/volume.py
+++ b/test/behave/steps/volume.py
@@ -4,7 +4,7 @@ from behave import given, then
 from mycroft.messagebus import Message
 from mycroft.audio import wait_while_speaking
 
-from test.integrationtests.voight_kampff import emit_utterance
+from test.integrationtests.voight_kampff import emit_utterance, then_wait
 
 
 @given("Mycroft audio is muted")
@@ -17,54 +17,58 @@ def given_muted(context):
 @given("the volume is set to 5")
 def given_volume_is_five(context):
     emit_utterance(context.bus, 'Set volume to 5')
-    context.volume = 0.5
-    sleep(1)
-    wait_while_speaking()
+
+    def check_volume_set_to_5(message):
+        """Ensure the volume set is set to 5."""
+        return message.data['percent'] == 0.5, ""
+
+    message_found, _ = then_wait(
+        "mycroft.volume.set", check_volume_set_to_5, context)
+    if message_found:
+        context.volume = 0.5
+        wait_while_speaking()
     context.bus.clear_messages()
+    assert message_found
 
 
 @given("the volume is set to 10")
 def given_volume_is_ten(context):
     emit_utterance(context.bus, 'Set volume to 10')
-    context.volume = 1.0
-    sleep(1)
-    wait_while_speaking()
+
+    def check_volume_set_to_10(message):
+        """Ensure the volume set is set to 10."""
+        return message.data['percent'] == 1.0, ""
+
+    message_found, _ = then_wait(
+        "mycroft.volume.set", check_volume_set_to_10, context)
+    if message_found:
+        context.volume = 1.0
+        wait_while_speaking()
     context.bus.clear_messages()
+    assert message_found
 
 
 @then('"mycroft-volume" should decrease the volume')
 def then_decrease(context):
-    cnt = 0
-    msgs = context.bus.get_messages('mycroft.volume.set')
 
-    while msgs == []:
-        if cnt > 20:
-            assert False, "Message not found"
-            break
-        else:
-            cnt += 1
-        sleep(0.5)
-        msgs = context.bus.get_messages('mycroft.volume.set')
-    if msgs:
-        err_info = "Volume hasn't decreased!"
-        print(msgs[0].data['percent'])
-        assert msgs[0].data['percent'] < context.volume, err_info
+    def check_volume_decreased(message):
+        """Ensure the volume set is lower than the previous volume."""
+        volume_did_decrease = message.data['percent'] < context.volume
+        return volume_did_decrease, ""
+
+    message_found, _ = then_wait(
+        "mycroft.volume.set", check_volume_decreased, context)
+    assert message_found, "No matching message received. "
 
 
 @then('"mycroft-volume" should increase the volume')
 def then_increase(context):
-    cnt = 0
-    msgs = context.bus.get_messages('mycroft.volume.set')
 
-    while msgs == []:
-        if cnt > 20:
-            assert False, "Message not found"
-            break
-        else:
-            cnt += 1
-        sleep(0.5)
-        msgs = context.bus.get_messages('mycroft.volume.set')
-    if msgs:
-        err_info = "Volume hasn't increased!"
-        print(msgs[0].data['percent'])
-        assert msgs[0].data['percent'] > context.volume, err_info
+    def check_volume_increased(message):
+        """Ensure the volume set is higher than the previous volume."""
+        volume_did_decrease = message.data['percent'] > context.volume
+        return volume_did_decrease, ""
+
+    message_found, _ = then_wait(
+        "mycroft.volume.set", check_volume_increased, context)
+    assert message_found, "No matching message received. "


### PR DESCRIPTION
#### Description
This switches the Volume Skills custom VK Steps to use the new `then_wait` method. This method uses an event handler rather than continuously looping.

I did this while debugging some VK errors but they turned out to be unrelated. Still a good change, but not immediately necessary.

#### Type of PR
- [x] Test improvements

#### Testing
Run the VK tests:
```
mycroft-start vktest -t mycroft-volume --tags=~@xfail
```