### PR TITLE
Ensure type is String

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -368,8 +368,8 @@ class VolumeSkill(MycroftSkill):
         return vol
 
     def __get_volume_level(self, message, default=None):
-        """ Retrievs volume from message. """
-        level_str = message.data.get('Level', default)
+        """ Retrieves volume from message. """
+        level_str = str(message.data.get('Level', default))
         level = self.settings["default_level"]
 
         try:


### PR DESCRIPTION
#### Description
Reported that the `message.data["Level"]` may be returned as an int instead of the expected string. This ensures the type for anything down the line.

Fixes #78 

#### Type of PR
- [x] Bugfix

#### Testing
I haven't replicated the issue, but the change is very minimal and VK tests are passing.
