### PR TITLE
Add missing translation for French

### DIFF
--- a/dialog/fr-fr/volume.words.value
+++ b/dialog/fr-fr/volume.words.value
@@ -1,0 +1,3 @@
+loud,fort
+normal,normal
+quiet,silencieux


### PR DESCRIPTION
Since PR #77, the `_translate_volume_words()` function has been added which raise a warning if `volume.words.value` is missing.

This PR the warning for the French language.